### PR TITLE
v0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - '7.0'
   - '7.1'
-  - hhvm
   - nightly
 install: composer install
 script: bin/phpunit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 language: php
 php:
-  - '5.5'
-  - '5.6'
   - '7.0'
   - '7.1'
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
   - hhvm
   - nightly
 install: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ language: php
 php:
   - '7.0'
   - '7.1'
-  - nightly
 install: composer install
 script: bin/phpunit test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+===============================================================================
+
+# 0.5 (2017-10-20)
+-------------------------------------------------------------------------------
+  - [BC break] Removed `$class` parameter from `all()`, `get()`, `has()`, `keys()`, and `values()` methods.
+  - Added `only()` method
+  - Added php7 argument and return types
+  - Created changelog

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   },
   "require": {
-    "php": ">=5.5"
+    "php": ">=7"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8",

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Enum;
 
 abstract class Enum

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -26,10 +26,11 @@ abstract class Enum
 
     /**
      * Enum constructor.
+     *
      * @param string $key
      * @param mixed $value
      */
-    private function __construct($key, $value)
+    private function __construct(string $key, $value)
     {
         $this->key = $key;
         $this->value = $value;
@@ -37,15 +38,17 @@ abstract class Enum
 
     /**
      * Returns enum key - constant name
+     *
      * @return string
      */
-    public function key()
+    public function key(): string
     {
         return $this->key;
     }
 
     /**
      * Returns enum value - constant value
+     *
      * @return mixed
      */
     public function value()
@@ -55,20 +58,21 @@ abstract class Enum
 
     /**
      * Get all enum items of particular enum class
-     * @param string|null $class
-     * @return \static[]|Enum[]
-     * @throws EnumException
+     *
+     * @return \static[]
      */
-    public static function all($class = null)
+    public static function all(): array
     {
-        $class = $class ?: get_called_class();
+        $class = get_called_class();
 
         if (isset(self::$items[$class])) {
             return self::$items[$class];
         }
 
-        $constants = self::constants($class);
+        $constants = static::constants();
+
         $items = [];
+
         foreach ($constants as $key => $value) {
             $items[$value] = new $class($key, $value);
         }
@@ -77,43 +81,65 @@ abstract class Enum
     }
 
     /**
-     * Returns an enum item with given value
-     * @param mixed $value
-     * @param string|null $class
-     * @return \static|Enum
+     * Returns enum instances only with given values
+     *
+     * @param array $values
+     * @return \static[]
      * @throws EnumException
      */
-    public static function get($value, $class = null)
+    public static function only(array $values): array
     {
+        $items = [];
+
+        foreach ($values as $value) {
+            $item = static::get($value);
+            $items[$item->value()] = $item;
+        }
+
+        return $items;
+    }
+
+    /**
+     * Returns an enum item with given value
+     *
+     * @param mixed $value
+     * @return \static
+     * @throws EnumException
+     */
+    public static function get($value): self
+    {
+        $class = get_called_class();
+
         if ($value instanceof self) {
             $value = $value->value();
         }
 
-        if (!static::has($value, $class)) {
+        if (!static::has($value)) {
             throw EnumException::invalidEnumValue($class, $value);
         }
 
-        return static::all($class)[$value];
+        return static::all()[$value];
     }
 
     /**
      * Tells if the enum contains a particular value
+     *
      * @param mixed $value
-     * @param string|null $class
      * @return bool
      */
-    public static function has($value, $class = null)
+    public static function has($value): bool
     {
-        return array_key_exists($value, static::all($class));
+        return array_key_exists($value, static::all());
     }
 
     /**
      * Compares enum object with given value.
+     *
      * @param mixed $value
      * @param boolean $strict Also checks the given value's type
      * @return boolean
      */
-    public function is($value, $strict = false)
+    public function is($value, ?bool $strict = false): bool
     {
         if ($this === $value) {
             return true;
@@ -132,10 +158,11 @@ abstract class Enum
 
     /**
      * Checks if this enum is contained in the given array of values
+     *
      * @param array $values
      * @return bool
      */
-    public function in(array $values)
+    public function in(array $values): bool
     {
         foreach ($values as $value) {
             if ($this->is($value)) {
@@ -148,32 +175,30 @@ abstract class Enum
 
     /**
      * Returns all enum keys of particular class
-     * @param string|null $class
+     *
      * @return string[]
-     * @throws EnumException
      */
-    public static function keys($class = null)
+    public static function keys(): array
     {
-        return array_keys(static::constants($class));
+        return array_keys(static::constants());
     }
 
     /**
      * Returns all enum values of particular class
-     * @param string|null $class
+     *
      * @return array
-     * @throws EnumException
      */
-    public static function values($class = null)
+    public static function values(): array
     {
-        return array_values(static::constants($class));
+        return array_values(static::constants());
     }
 
     /**
      * Returns label
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->key;
+        return (string)$this->value();
     }
 
     /**
@@ -203,20 +228,15 @@ abstract class Enum
 
     /**
      * Returns constants map of given class
-     * @param string $class
+     *
      * @return array
-     * @throws EnumException
      */
-    private static function constants($class = null)
+    private static function constants(): array
     {
-        $class = $class ?: get_called_class();
+        $class = get_called_class();
 
         if (isset(self::$constants[$class])) {
             return self::$constants[$class];
-        }
-
-        if (!is_subclass_of($class, self::class)) {
-            throw EnumException::notValidEnumClass($class);
         }
 
         $reflection = new \ReflectionClass($class);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -139,7 +139,7 @@ abstract class Enum
      * @param boolean $strict Also checks the given value's type
      * @return boolean
      */
-    public function is($value, ?bool $strict = false): bool
+    public function is($value, bool $strict = false): bool
     {
         if ($this === $value) {
             return true;

--- a/src/EnumException.php
+++ b/src/EnumException.php
@@ -1,33 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Enum;
 
 class EnumException extends \Exception
 {
-    /**
-     * @param string $class
-     * @return EnumException
-     */
-    public static function notValidEnumClass($class)
+    public static function notValidEnumClass(string $class): self
     {
         return new self('Class '.$class.' is not a valid enum class.');
     }
 
-    /**
-     * @param string $class
-     * @param string $value
-     * @return EnumException
-     */
-    public static function invalidEnumValue($class, $value)
+    public static function invalidEnumValue(string $class, $value): self
     {
         return new self(sprintf('Enum class %s does not have value: %s.', $class, $value));
     }
 
-    /**
-     * @param string $class
-     * @return EnumException
-     */
-    public static function notCloneable($class)
+    public static function notCloneable(string $class): self
     {
         return new self($class . ' is not cloneable.');
     }

--- a/test/EnumTest.php
+++ b/test/EnumTest.php
@@ -2,8 +2,6 @@
 
 namespace test\Enum;
 
-use Enum\Enum;
-
 class EnumTest extends \PHPUnit_Framework_TestCase
 {
     public function testAll()
@@ -21,6 +19,26 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $bar->value());
     }
 
+    public function testOnly()
+    {
+        $items = ExampleEnum::only([ExampleEnum::FOO, ExampleEnum::BAR]);
+        $this->assertCount(2, $items);
+        $this->assertContainsOnlyInstancesOf(ExampleEnum::class, $items);
+
+        $this->assertEquals(ExampleEnum::FOO(), $items[ExampleEnum::FOO]);
+        $this->assertEquals(ExampleEnum::BAR(), $items[ExampleEnum::BAR]);
+        $this->assertEquals(
+            ExampleEnum::only([
+                ExampleEnum::FOO(),
+                ExampleEnum::BAR(),
+            ]),
+            ExampleEnum::only([
+                ExampleEnum::FOO,
+                ExampleEnum::BAR,
+            ])
+        );
+    }
+
     public function testGet()
     {
         $foo = ExampleEnum::get(ExampleEnum::FOO);
@@ -34,6 +52,8 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('BAR', $bar->key());
         $this->assertEquals('bar', $bar->value());
         $this->assertEquals($bar, ExampleEnum::get($bar));
+
+        $this->assertEquals($foo, ExampleEnum::get($foo));
     }
 
     public function testIs()
@@ -71,35 +91,8 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         $foo = ExampleEnum::get(ExampleEnum::FOO);
         $bar = ExampleEnum::get(ExampleEnum::BAR);
 
-        $this->assertEquals('FOO', (string)$foo);
-        $this->assertEquals('BAR', (string)$bar);
-    }
-
-    public function testGetAndAllWithClassName()
-    {
-        $this->assertEquals(ExampleEnum::all(), Enum::all(ExampleEnum::class));
-        $foo = ExampleEnum::get(ExampleEnum::FOO);
-        $bar = ExampleEnum::get(ExampleEnum::BAR);
-        $this->assertEquals($foo, Enum::get(ExampleEnum::FOO, ExampleEnum::class));
-        $this->assertEquals($bar, Enum::get(ExampleEnum::BAR, ExampleEnum::class));
-        $this->assertEquals($foo, Enum::get($foo, ExampleEnum::class));
-        $this->assertEquals($bar, Enum::get($bar, ExampleEnum::class));
-    }
-
-    /**
-     * @expectedException \Enum\EnumException
-     */
-    public function testGetThrowsExceptionWhenClassDoesntExist()
-    {
-        Enum::get(ExampleEnum::FOO, 'some_fake_class');
-    }
-
-    /**
-     * @expectedException \Enum\EnumException
-     */
-    public function testAllThrowsExceptionWhenClassDoesntExist()
-    {
-        Enum::all('some_fake_class');
+        $this->assertEquals('foo', (string)$foo);
+        $this->assertEquals('bar', (string)$bar);
     }
 
     public function testCallStatic()
@@ -116,18 +109,24 @@ class EnumTest extends \PHPUnit_Framework_TestCase
         ExampleEnum::WRONG();
     }
 
+    /**
+     * @expectedException \Enum\EnumException
+     */
+    public function testGetThrowsExceptionWhenValueDoesntExist()
+    {
+        ExampleEnum::get('wrong_value');
+    }
+
     public function testKeys()
     {
         $expected = ['FOO', 'BAR', 'XYZ'];
         $this->assertEquals($expected, ExampleEnum::keys());
-        $this->assertEquals($expected, Enum::keys(ExampleEnum::class));
     }
 
     public function testValues()
     {
         $expected = ['foo', 'bar', 'xyz'];
         $this->assertEquals($expected, ExampleEnum::values());
-        $this->assertEquals($expected, Enum::values(ExampleEnum::class));
     }
 
     /**
@@ -144,7 +143,6 @@ class EnumTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue(ExampleEnum::has('foo'));
         $this->assertTrue(ExampleEnum::has('bar'));
-        $this->assertTrue(Enum::has('xyz', ExampleEnum::class));
         $this->assertFalse(ExampleEnum::has('wrong'));
     }
 }

--- a/test/EnumTest.php
+++ b/test/EnumTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\Enum;
 
 class EnumTest extends \PHPUnit_Framework_TestCase

--- a/test/ExampleEnum.php
+++ b/test/ExampleEnum.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace test\Enum;
 
 use Enum\Enum;
 
 /**
- * Class ExampleEnum
- * @package test\Enum
  * @method static string FOO()
  * @method static string BAR()
  * @method static string XYZ()


### PR DESCRIPTION
- [BC break] Removed `$class` parameter from `all()`, `get()`, `has()`, `keys()`, and `values()` methods.
- Added `only()` method
- Added php7 argument and return types
- Created changelog